### PR TITLE
Some new text for the community testing policy

### DIFF
--- a/docs/policy/community-testing.md
+++ b/docs/policy/community-testing.md
@@ -37,6 +37,7 @@ The following packages are considered critical to the production Open Science Gr
 - CVMFS
 - Frontier Squid
 - GlideinWMS
+- HDFS
 - HTCondor
 - HTCondor-CE
 - Singularity

--- a/docs/policy/community-testing.md
+++ b/docs/policy/community-testing.md
@@ -1,46 +1,47 @@
 OSG Community Software Testing
 ==============================
 
-In the past, the OSG utilized internal staff for the bulk of software testing.
-Interested external administrators also provided testing when their specialized installation was required.
+20 February 2019
 
-More recently, we have been employing an ad hoc community testing program.
-The release manager is responsible for notifying interested parties and coordinating their testing.
-Often, the person that reported an issue was asked to verify that the issue was resolved.
-
-Testing Model
--------------
-
-We want to engage the OSG community in testing OSG software.
-The community has a vested interest in ensuring that the software operates properly.
-We will adopt a more formal testing policy which should require less effort from the release manager.
-
-- Promotion: The software is `Ready to Test` when the release is promoted to `osg-testing` repository.
-- Notification: The release manager posts a message to the community when testing is desired.
-- Feedback: Interested testers provide positive or negative feedback about the software by responding to the posted message.
-- Release: After the software has met the release requirements, it is released.
-    - Major Packages
-        - Spent at least 7 calendar days in the osg-testing repository
-        - Some positive feedback
-        - Approval of the Release Manager
-        - No negative feedback
-    - Minor Packages
-        - Spent at least 7 calendar days in the osg-testing repository
-        - No negative feedback
-    - Timing
-        - Releases are scheduled by the Release Manager
-        - Releases will generally occur Monday - Thursday
-        - Releases will generally not occur the day before an non-working day
+The community of OSG resource providers has a vested interested in the quality and stability of the OSG software stack.
+We would like to notify our stakeholders of software updates as soon as they are designated as "Ready for Testing" by
+the Software Team.
+Direct engagement with the entire community would allow for feedback from a broader array of interested parties.
+Combined with our [flexible release model](/release/flexible-release-model), we hope to further improve the turnaround
+time of new features and bug fixes.
 
 Implementation
 --------------
 
-We will use an `osg-testing` Google group to manage the notifications and feedback.
-The release manager posts a message requesting testing to the `osg-testing` group
-for each package or related set of packages to be tested.
-Interested parties will test the software a provide feedback by replying to the post.
-The release manager will periodically review the postings in the Google group and
-mark tickets `Ready to Release` when they meet the release requirements.
+After the OSG Software Team builds and tests a package succesfully, it is marked "Ready for Testing" and is added to the
+appropriate Yum testing repository:
+`osg-testing` and `osg-upcoming-testing` for packages targeted for the release and the upcoming release, respectively.
+Upon addition to the relevant testing repository, we intend to notify OSG site administrators that the package is
+available for testing with a description of changes compared to previously released versions and provide a forum by
+which interested users can provide feedback.
 
-Package are designated `major` or `minor` at the discretion of the release manager
-with input from the Software and Operation teams.
+The Software and Release team will classify packages as either ["major"](#major-packages) or "minor"; where major
+packages are deemed critical to the functionality of the production grid and all other packages are minor.
+After users have been notified of changes, minor packages will be marked eligible for release if they have not received
+negative feedback after 7 calendar days.
+In addition to the above requirements, major packages must also receive positive feedback and be approved by the Release
+Manager.
+If any package receives negative feedback, the package will be removed from the relevant testing repository.
+
+Major Packages
+--------------
+
+The following packages are considered critical to the production Open Science Grid:
+
+- BLAHP
+- CVMFS
+- Frontier Squid
+- GlideinWMS
+- HTCondor
+- HTCondor-CE
+- Singularity
+- StashCache
+- XRootD
+
+This list is maintained by the Release Manager with input from OSG stakeholders, the Software Manager, and the
+Operations Manager.

--- a/docs/policy/community-testing.md
+++ b/docs/policy/community-testing.md
@@ -1,9 +1,6 @@
 OSG Community Software Testing
 ==============================
 
-Introduction
-------------
-
 In the past, the OSG utilized internal staff for the bulk of software testing.
 Interested external administrators also provided testing when their specialized installation was required.
 

--- a/docs/policy/community-testing.md
+++ b/docs/policy/community-testing.md
@@ -16,9 +16,9 @@ Implementation
 After the OSG Software Team builds and tests a package succesfully, it is marked "Ready for Testing" and is added to the
 appropriate Yum testing repository:
 `osg-testing` and `osg-upcoming-testing` for packages targeted for the release and the upcoming release, respectively.
-Upon addition to the relevant testing repository, we intend to notify OSG site administrators that the package is
-available for testing with a description of changes compared to previously released versions and provide a forum by
-which interested users can provide feedback.
+Upon addition to the relevant testing repository, we intend to notify OSG site administrators that the package, or a
+logically connected group of packages, is available for testing with a description of changes compared to previously
+released versions and provide a forum by which interested users can provide feedback.
 
 The Software and Release team will classify packages as either ["major"](#major-packages) or "minor"; where major
 packages are deemed critical to the functionality of the production grid and all other packages are minor.


### PR DESCRIPTION
In case it comes up, OSG 3.4 releases have 15 packages on average (excluding data releases, ~14 without osg-version). If people think 15+ notifications per release is too much, we could 1) limit notifications to admins where the package is relevant and/or 2) only notify admins of major packages and have an RSS feed or something for minor packages